### PR TITLE
Restore patches and py27 testing

### DIFF
--- a/recipe/0001-Mach-O-Copy-any-dynamic-libraries-and-symlinks-to-th.patch
+++ b/recipe/0001-Mach-O-Copy-any-dynamic-libraries-and-symlinks-to-th.patch
@@ -1,25 +1,23 @@
-From 258a0b764df7e085ab46785cab7b07ec52d07d4c Mon Sep 17 00:00:00 2001
-From: William Jamir Silva <williamjamir@gmail.com>
+From 4bee3f3db358956e3d94e64ec37abc3de8a04951 Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sun, 2 Jun 2019 21:11:26 -0300
-Subject: [PATCH 1/2] Mach-O: Copy any dynamic libraries and symlinks to the 
+Subject: [PATCH 1/2] Mach-O: Copy any dynamic libraries and symlinks to the
  correct relative location
 
 This is done exhaustively (i.e. recursively). Files that would end
 up being located outside of home_dir are not copied to prevent any
 security issues. An implementation for elf will be added soon.
 
-Patche original created by:
-    From: Ray Donnelly <mingw.android@gmail.com>
-    Date: Thu, 9 Feb 2017 19:21:55 +0000
+PEP-8 and small fixes by Nicola Soranzo <nicola.soranzo@earlham.ac.uk>, 2019-08-19
 ---
  virtualenv.py | 325 ++++++++++++++++++++++++++++++++++++++++++--------
  1 file changed, 275 insertions(+), 50 deletions(-)
 
 diff --git a/virtualenv.py b/virtualenv.py
-index cd76bf6..e888429 100755
+index 8f05739..a6bd076 100755
 --- a/virtualenv.py
 +++ b/virtualenv.py
-@@ -1475,7 +1475,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
+@@ -1523,7 +1523,7 @@ def install_python(home_dir, lib_dir, inc_dir, bin_dir, site_packages, clear, sy
      if sys.executable != py_executable:
          # FIXME: could I just hard link?
          executable = sys.executable
@@ -28,7 +26,7 @@ index cd76bf6..e888429 100755
          make_exe(py_executable)
          if IS_WIN or IS_CYGWIN:
              python_w = os.path.join(os.path.dirname(sys.executable), "pythonw.exe")
-@@ -2440,6 +2440,10 @@ MZWF36ryyXXf3yBIz6nzqz8Muyz0m5Qj7OexfYo/Ph3LqvkHUg7AuA==
+@@ -2490,6 +2490,10 @@ MZWF36ryyXXf3yBIz6nzqz8Muyz0m5Qj7OexfYo/Ph3LqvkHUg7AuA==
  """
  )
  
@@ -39,7 +37,7 @@ index cd76bf6..e888429 100755
  MH_MAGIC = 0xFEEDFACE
  MH_CIGAM = 0xCEFAEDFE
  MH_MAGIC_64 = 0xFEEDFACF
-@@ -2448,6 +2452,8 @@ FAT_MAGIC = 0xCAFEBABE
+@@ -2498,6 +2502,8 @@ FAT_MAGIC = 0xCAFEBABE
  BIG_ENDIAN = ">"
  LITTLE_ENDIAN = "<"
  LC_LOAD_DYLIB = 0xC
@@ -48,14 +46,14 @@ index cd76bf6..e888429 100755
  maxint = MAJOR == 3 and getattr(sys, "maxsize") or getattr(sys, "maxint")
  
  
-@@ -2521,6 +2527,97 @@ def read_data(file, endian, num=1):
-         return res[0]
+@@ -2572,63 +2578,282 @@ def read_data(file, endian, num=1):
      return res
  
+ 
 +def replace_lc_load_dylib(file, where, bits, endian, cmd, cmdsize, what, value):
-+   if cmd == LC_LOAD_DYLIB:
-+       # The first data field in LC_LOAD_DYLIB commands is the
-+       # offset of the name, starting from the beginning of the
++    if cmd == LC_LOAD_DYLIB:
++        # The first data field in LC_LOAD_DYLIB commands is the
++        # offset of the name, starting from the beginning of the
 +        # command.
 +        name_offset = read_data(file, endian)
 +        file.seek(where + name_offset, os.SEEK_SET)
@@ -123,7 +121,7 @@ index cd76bf6..e888429 100755
 +
 +
 +def do_file(file, lc_operation, off_sz, results, *args):
-+    file = fileview(file, off_sz.offset, off_sz.size)
++    file = FileView(file, off_sz.offset, off_sz.size)
 +    # Read magic number
 +    magic = read_data(file, BIG_ENDIAN)
 +    if magic == FAT_MAGIC:
@@ -143,10 +141,9 @@ index cd76bf6..e888429 100755
 +        results.append(do_macho(file, 64, LITTLE_ENDIAN, lc_operation, *args))
 +
 +
- 
  def mach_o_change(at_path, what, value):
      """
-@@ -2528,57 +2625,185 @@ def mach_o_change(at_path, what, value):
+     Replace a given name (what) in any LC_LOAD_DYLIB command found in
      the given binary with a new name (value), provided it's shorter.
      """
  
@@ -310,7 +307,7 @@ index cd76bf6..e888429 100755
 +
 +
 +def codefile(file, initial_rpaths_transitive=[]):
-+    magic, = struct.unpack(BIG_ENDIAN+'L', file.read(4))
++    magic, = struct.unpack(BIG_ENDIAN + 'L', file.read(4))
 +    file.seek(0)
 +    if magic in (FAT_MAGIC, MH_MAGIC, MH_CIGAM, MH_CIGAM_64):
 +        return machofile(file, list(initial_rpaths_transitive))
@@ -329,15 +326,15 @@ index cd76bf6..e888429 100755
 +    dsts = [exe_dst]
 +    all_srcs = set(srcs)
 +    all_done = set()
-+    dir_exe_src = os.path.dirname(exe_src)+os.sep
-+    dir_exe_dst = os.path.dirname(exe_dst)+os.sep
++    dir_exe_src = os.path.dirname(exe_src) + os.sep
++    dir_exe_dst = os.path.dirname(exe_dst) + os.sep
 +    src_to_dst_rpath = dict({exe_src: (exe_dst, [])})
 +    rpaths = []
 +    while all_srcs != all_done:
 +        for src in all_srcs - all_done:
 +            dst, rpaths = src_to_dst_rpath[src]
-+            dir_src = os.path.dirname(src)+os.sep
-+            dir_dst = os.path.dirname(dst)+os.sep
++            dir_src = os.path.dirname(src) + os.sep
++            dir_dst = os.path.dirname(dst) + os.sep
 +            with open(src, 'rb') as f:
 +                new_srcs = set()
 +                of = codefile(f, rpaths)
@@ -375,12 +372,12 @@ index cd76bf6..e888429 100755
 +            print('copying {} => {}'.format(src, dst))
 +            try:
 +                os.makedirs(os.path.dirname(dst))
-+            except:
++            except Exception:
 +                pass
 +            shutil.copyfile(src, dst)
  
  
  if __name__ == "__main__":
 -- 
-2.20.1
+2.17.1
 

--- a/recipe/0002-ELF-Copy-any-dynamic-libraries-and-symlinks-to-the-c.patch
+++ b/recipe/0002-ELF-Copy-any-dynamic-libraries-and-symlinks-to-the-c.patch
@@ -1,5 +1,5 @@
-From fa72c3223855e9dad067a9ddc3e47345d5eca1dd Mon Sep 17 00:00:00 2001
-From: William Jamir Silva <williamjamir@gmail.com>
+From 35cc8b69b737d747e7c7f031efaa886521fd65ea Mon Sep 17 00:00:00 2001
+From: Ray Donnelly <mingw.android@gmail.com>
 Date: Sun, 2 Jun 2019 21:18:08 -0300
 Subject: [PATCH 2/2] ELF: Copy any dynamic libraries and symlinks to the
  correct relative location
@@ -10,19 +10,15 @@ the same results in all cases, but for the purposes of virtualenv, this
 code seems to work well enough.
 
 Tested this with both big and little-endian ELF files.
-
-Patch original created by:
-    From: Ray Donnelly <mingw.android@gmail.com>
-    Date: Thu, 9 Feb 2017 19:25:40 +0000
 ---
  virtualenv.py | 314 ++++++++++++++++++++++++++++++++++++++++++++++++++
  1 file changed, 314 insertions(+)
 
 diff --git a/virtualenv.py b/virtualenv.py
-index e888429..4af58f0 100755
+index a6bd076..0e99d67 100755
 --- a/virtualenv.py
 +++ b/virtualenv.py
-@@ -2717,6 +2717,318 @@ class machofile(object):
+@@ -2767,6 +2767,318 @@ class machofile(object):
      def is_executable(self):
          return True
  
@@ -341,7 +337,7 @@ index e888429..4af58f0 100755
  
  class inscrutablefile(object):
      def __init__(self, file, initial_rpaths_transitive=[]):
-@@ -2740,6 +3052,8 @@ def codefile(file, initial_rpaths_transitive=[]):
+@@ -2790,6 +3102,8 @@ def codefile(file, initial_rpaths_transitive=[]):
      file.seek(0)
      if magic in (FAT_MAGIC, MH_MAGIC, MH_CIGAM, MH_CIGAM_64):
          return machofile(file, list(initial_rpaths_transitive))
@@ -351,5 +347,5 @@ index e888429..4af58f0 100755
          return inscrutablefile(file, list(initial_rpaths_transitive))
  
 -- 
-2.20.1
+2.17.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,10 +7,13 @@ package:
 source:
   url: https://github.com/pypa/virtualenv/archive/{{ version }}.tar.gz
   sha256: 74eb96b4e1eb08fbe37b5c6fbad9c978e1c9461013378f5df7637c2d8eccb18e
+  patches:
+    - 0001-Mach-O-Copy-any-dynamic-libraries-and-symlinks-to-th.patch
+    - 0002-ELF-Copy-any-dynamic-libraries-and-symlinks-to-the-c.patch
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:
     - virtualenv = virtualenv:main
@@ -28,9 +31,9 @@ test:
     # Skipping py2k tests b/c it fails on our docker image
     # but I'm 99% sure it should work locally.
     - |
-      virtualenv -p "$(which python)" /tmp/venv-$$  # [not (win or py2k)]
-      source /tmp/venv-$$/bin/activate  # [not (win or py2k)]
-      python -c 'import sys ; sys.exit(not hasattr(sys, "real_prefix"))'  # [not (win or py2k)]
+      virtualenv -p "$(which python)" /tmp/venv-$$  # [not win]
+      source /tmp/venv-$$/bin/activate  # [not win]
+      python -c 'import sys ; sys.exit(not hasattr(sys, "real_prefix"))'  # [not win]
   imports:
     - virtualenv
 


### PR DESCRIPTION
Broken in PR https://github.com/conda-forge/virtualenv-feedstock/pull/16 , which affects all `>=16.6.2` py27 packages.

How to reproduce:
```
$ ~/miniconda3/bin/conda create -n 'virtualenv@16.0.0_py27' virtualenv=16.0.0 python=2.7
...
$ . ~/miniconda3/bin/activate virtualenv@16.0.0_py27
(virtualenv@16.0.0_py27)$ virtualenv /tmp/venv
New python executable in /tmp/venv/bin/python
copying /usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/bin/python => /tmp/venv/bin/python
copying /usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/bin/../lib/libpython2.7.so.1.0 => /tmp/venv/lib/libpython2.7.so.1.0
Installing setuptools, pip, wheel...done.
(virtualenv@16.0.0_py27) soranzon@n140522:~/software/nsoranzo_galaxy$ conda install virtualenv=16.6.2
...
(virtualenv@16.0.0_py27) soranzon@n140522:~/software/nsoranzo_galaxy$ virtualenv /tmp/venv2
New python executable in /tmp/venv2/bin/python
Command /tmp/venv2/bin/python -m pip config list had error code 1
Installing setuptools, pip, wheel...

  Complete output from command /tmp/venv2/bin/python - setuptools pip wheel:
  Traceback (most recent call last):
  File "<stdin>", line 10, in <module>
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv_support/pip-19.1.1-py2.py3-none-any.whl/pip/_internal/__init__.py", line 40, in <module>
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv_support/pip-19.1.1-py2.py3-none-any.whl/pip/_internal/cli/autocompletion.py", line 8, in <module>
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv_support/pip-19.1.1-py2.py3-none-any.whl/pip/_internal/cli/main_parser.py", line 8, in <module>
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv_support/pip-19.1.1-py2.py3-none-any.whl/pip/_internal/cli/cmdoptions.py", line 19, in <module>
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv_support/pip-19.1.1-py2.py3-none-any.whl/pip/_internal/locations.py", line 98, in <module>
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/platform.py", line 1460, in python_implementation
    return _sys_version()[0]
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/platform.py", line 1422, in _sys_version
    repr(sys_version))
ValueError: failed to parse CPython sys.version: '2.7.15+ (default, Nov 27 2018, 23:36:35) \n[GCC 7.3.0]'
----------------------------------------
...Installing setuptools, pip, wheel...done.
Traceback (most recent call last):
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/bin/virtualenv", line 11, in <module>
    sys.exit(main())
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv.py", line 867, in main
    symlink=options.symlink,
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv.py", line 1159, in create_environment
    install_wheel(to_install, py_executable, search_dirs, download=download)
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv.py", line 1009, in install_wheel
    _install_wheel_with_search_dir(download, project_names, py_executable, search_dirs)
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv.py", line 1096, in _install_wheel_with_search_dir
    call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=script)
  File "/usr/users/ga002/soranzon/miniconda3/envs/virtualenv@16.0.0_py27/lib/python2.7/site-packages/virtualenv.py", line 960, in call_subprocess
    raise OSError("Command {} failed with error code {}".format(cmd_desc, proc.returncode))
OSError: Command /tmp/venv2/bin/python - setuptools pip wheel failed with error code 1
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
