### PR TITLE
Mark virtualenv 20.35.0 as broken

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,3 +55,5 @@ extra:
     - mingwandroid
     - kalefranz
     - xylar
+  patch_broken:
+    "20.35.0": "Broken release, yanked from PyPI"


### PR DESCRIPTION
## Summary
- Marks virtualenv 20.35.0 as broken in the recipe

## Reason
This release was yanked from PyPI due to being broken. Adding `patch_broken` entry to prevent users from installing this version via conda-forge.

## Test plan
- [ ] CI passes
- [ ] Version 20.35.0 is marked as broken in conda-forge

🤖 Generated with [Claude Code](https://claude.com/claude-code)